### PR TITLE
Add Save button functionality to FormattedPane component (#29)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -397,6 +397,7 @@ export default function App() {
                 formatMode={activeFormatState.formatMode}
                 setFormatMode={setActiveFormatMode}
                 onTreeEdit={onTreeEdit}
+                tabName={activeTab.name}
               />
             </>
           )}

--- a/src/app/components/FormattedPane.test.tsx
+++ b/src/app/components/FormattedPane.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import FormattedPane from './FormattedPane';
 
 describe('FormattedPane', () => {
@@ -19,5 +20,82 @@ describe('FormattedPane', () => {
     expect(copyBtn).toHaveAttribute('title', 'Copy');
     expect(screen.queryByRole('button', { name: /paste/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /clear/i })).not.toBeInTheDocument();
+  });
+
+  it('renders Save button with aria-label and title', () => {
+    render(
+      <FormattedPane
+        parsed={{ example: true }}
+        parseError={null}
+        formatMode="formatted"
+        setFormatMode={() => {}}
+        onTreeEdit={() => {}}
+      />
+    );
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+    expect(saveBtn).toBeInTheDocument();
+    expect(saveBtn).toHaveAttribute('aria-label', 'Save');
+    expect(saveBtn).toHaveAttribute('title', 'Save');
+    expect(saveBtn.querySelector('.fa-floppy-disk')).toBeInTheDocument();
+  });
+
+  it('disables Save button when parsed is null', () => {
+    render(
+      <FormattedPane
+        parsed={null}
+        parseError={null}
+        formatMode="formatted"
+        setFormatMode={() => {}}
+        onTreeEdit={() => {}}
+      />
+    );
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+    expect(saveBtn).toBeDisabled();
+  });
+
+  it('enables Save button when parsed is valid', () => {
+    render(
+      <FormattedPane
+        parsed={{ example: true }}
+        parseError={null}
+        formatMode="formatted"
+        setFormatMode={() => {}}
+        onTreeEdit={() => {}}
+      />
+    );
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+    expect(saveBtn).not.toBeDisabled();
+  });
+
+  it('triggers download with JSON blob when Save is clicked', async () => {
+    const mockUrl = 'blob:mock-url';
+    const createObjectURL = vi.fn(() => mockUrl);
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL,
+    });
+
+    render(
+      <FormattedPane
+        parsed={{ foo: 1 }}
+        parseError={null}
+        formatMode="formatted"
+        setFormatMode={() => {}}
+        onTreeEdit={() => {}}
+        tabName="My Tab"
+      />
+    );
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+    await userEvent.click(saveBtn);
+
+    expect(createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe('application/json');
+    expect(await blob.text()).toBe(JSON.stringify({ foo: 1 }, null, 2));
+    expect(revokeObjectURL).toHaveBeenCalledWith(mockUrl);
+
+    vi.unstubAllGlobals();
   });
 });

--- a/src/app/components/FormattedPane.test.tsx
+++ b/src/app/components/FormattedPane.test.tsx
@@ -91,7 +91,8 @@ describe('FormattedPane', () => {
     await userEvent.click(saveBtn);
 
     expect(createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
-    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    const calls = createObjectURL.mock.calls as unknown as [Blob][];
+    const blob = calls[0][0];
     expect(blob.type).toBe('application/json');
     expect(await blob.text()).toBe(JSON.stringify({ foo: 1 }, null, 2));
     expect(revokeObjectURL).toHaveBeenCalledWith(mockUrl);

--- a/src/app/components/FormattedPane.tsx
+++ b/src/app/components/FormattedPane.tsx
@@ -3,12 +3,20 @@ import type { JsonValue, FormatMode, TreeEditPath } from '../types';
 import FormattedJsonView from './FormattedJsonView';
 import JsonTreeView from './JsonTreeView';
 
+function fileNameFromTabName(tabName: string): string {
+  const invalid = /[\\/:*?"<>|]/g;
+  const sanitized = (tabName ?? '').trim().replace(invalid, '').trim();
+  const base = sanitized || 'format';
+  return base.toLowerCase().endsWith('.json') ? base : `${base}.json`;
+}
+
 type FormattedPaneProps = {
   parsed: JsonValue | null
   parseError: string | null
   formatMode: FormatMode
   setFormatMode: (m: FormatMode) => void
   onTreeEdit: (path: TreeEditPath, value: JsonValue) => void
+  tabName?: string
 }
 
 export default function FormattedPane({
@@ -17,6 +25,7 @@ export default function FormattedPane({
   formatMode,
   setFormatMode,
   onTreeEdit,
+  tabName,
 }: FormattedPaneProps) {
   const [copied, setCopied] = useState(false);
 
@@ -30,6 +39,17 @@ export default function FormattedPane({
     } catch {
       // ignore
     }
+  };
+
+  const handleSave = () => {
+    const filename = fileNameFromTabName(tabName ?? '');
+    const blob = new Blob([formattedString], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
   };
 
   return (
@@ -53,6 +73,16 @@ export default function FormattedPane({
               Tree view
             </button>
           </div>
+          <button
+            type="button"
+            className="pane-action-btn save-btn"
+            onClick={handleSave}
+            disabled={parsed === null}
+            aria-label="Save"
+            title="Save"
+          >
+            <i className="fa-solid fa-floppy-disk" aria-hidden="true" />
+          </button>
           <button
             type="button"
             className={`pane-action-btn copy-btn ${copied ? 'copied' : ''}`}


### PR DESCRIPTION
- Introduced a Save button in the FormattedPane that allows users to download the formatted JSON as a file.
- Implemented filename generation based on the active tab name, ensuring valid filenames.
- Added tests to verify the Save button's behavior, including enabling/disabling based on parsed data and confirming download functionality.
- Updated App component to pass the active tab name to FormattedPane.